### PR TITLE
fix(scripts): correct and prettify copy kv secrets script

### DIFF
--- a/scripts/powershell/Copy-AzKeyVaultSecret.ps1
+++ b/scripts/powershell/Copy-AzKeyVaultSecret.ps1
@@ -93,7 +93,7 @@ function aaLogin {
 }
 
 # Set and verify Azure Subscription Context
-function Set-Subscription {
+function Select-SubscriptionContext {
 
     param (
         [Parameter(Mandatory = $true)]
@@ -150,7 +150,7 @@ try {
     }
 
     # Set Context and make sure FireWall is set to "Allowed" to be able to access secrets
-    Set-Subscription -SubscriptionId $SubscriptionId
+    Select-SubscriptionContext -SubscriptionId $SubscriptionId
     $SourceVaultFirewall = Disable-KeyVaultFirewall -VaultName $SourceVaultName
     $TargetVaultFirewall = Disable-KeyVaultFirewall -VaultName $TargetVaultName
 

--- a/scripts/powershell/Copy-AzKeyVaultSecret.ps1
+++ b/scripts/powershell/Copy-AzKeyVaultSecret.ps1
@@ -93,7 +93,7 @@ function aaLogin {
 }
 
 # Set and verify Azure Subscription Context
-function Set-SubscriptionContext {
+function Set-Subscription {
 
     param (
         [Parameter(Mandatory = $true)]
@@ -150,7 +150,7 @@ try {
     }
 
     # Set Context and make sure FireWall is set to "Allowed" to be able to access secrets
-    Set-SubscriptionContext -SubscriptionId $SubscriptionId
+    Set-Subscription -SubscriptionId $SubscriptionId
     $SourceVaultFirewall = Disable-KeyVaultFirewall -VaultName $SourceVaultName
     $TargetVaultFirewall = Disable-KeyVaultFirewall -VaultName $TargetVaultName
 

--- a/scripts/powershell/Copy-AzKeyVaultSecret.ps1
+++ b/scripts/powershell/Copy-AzKeyVaultSecret.ps1
@@ -6,23 +6,23 @@
     - RBAC as Key Vault Contributor for Source and Destination Vault
     - Read access policy for secrets at source Key Vault and Write access policy for secrets at destination Key Vault
 
-  .PARAMETER VaultName
-  Specifies the name of the key vault.
+  .PARAMETER SourceVaultName
+  Specifies the name of the source key vault.
 
   .PARAMETER TargetVaultName
   Specifies the name of the target key vault.
 
   .PARAMETER SubscriptionId
-  Specifies the ID of Azure Subscription.
+  Specifies the ID of source Azure Subscription.
 
   .PARAMETER TargetSubscriptionId
-  Specifies the ID of Target Azure Subscription.
+  Specifies the ID of target Azure Subscription.
 
-  .PARAMETER Name
-  Specifies the name of the secret to copy. You can as well specify multiple Names for multiple secrets to copy.
+  .PARAMETER SecretName
+  Specifies the name of the secret to copy. You can as well specify multiple SecretNames for multiple secrets to copy.
 
   .PARAMETER SkipSecrets
-  Specifies the names of the secret skip copy operation.
+  Specifies the names of the secrets to skip during copy operation.
 
   .PARAMETER Force
   Forces the script to run without asking for user confirmation.
@@ -33,37 +33,33 @@
   .EXAMPLE
   This example shows how to copy all secrets from source to target vault.
   It requires manual user confirmation before executing copy operation for every secret separately:
-  .\Copy-AzKeyVaultSecret.ps1 -VaultName <String> -TargetVaultName <String> -Subscription $Subscription
+  .\Copy-AzKeyVaultSecret.ps1 -SourceVaultName <String> -TargetVaultName <String> -SubscriptionId <String>
 
   .EXAMPLE
   Similar to example above, this shows how to copy all secrets from source to target vault.
-  But this time script does not require user confirmation as it uses -Force argument.
-  .\Copy-AzKeyVaultSecret.ps1 -VaultName <String> -TargetVaultName <String> -Subscription $Subscription -Force
+  But this time the script does not require user confirmation as it uses -Force argument.
+  .\Copy-AzKeyVaultSecret.ps1 -SourceVaultName <String> -TargetVaultName <String> -SubscriptionId <String> -Force
 
   .EXAMPLE
-  This example shows how to use $Name Parameter to copy a single secret:
-  .\Copy-AzKeyVaultSecret.ps1 -VaultName <String> -TargetVaultName <String> -Subscription $Subscription -Name <String>
+  This example shows how to use $SecretName Parameter to copy a single secret:
+  .\Copy-AzKeyVaultSecret.ps1 -SourceVaultName <String> -TargetVaultName <String> -SubscriptionId <String> -SecretName <String>
 
   .EXAMPLE
-  This example shows how to use $Name Parameter to copy multiple secrets:
-  .\Copy-AzKeyVaultSecret.ps1 -VaultName <String> -TargetVaultName <String> -Subscription $Subscription -Name <String>, <String>, <String>
+  This example shows how to use $SecretName Parameter to copy multiple secrets:
+  .\Copy-AzKeyVaultSecret.ps1 -SourceVaultName <String> -TargetVaultName <String> -SubscriptionId <String> -SecretName <String>, <String>, <String>
 
   .EXAMPLE
-  This example shows how to copy all secrets from source to target vault without any confirmation:
-  .\Copy-AzKeyVaultSecret.ps1 -VaultName <String> -TargetVaultName <String> -Subscription $Subscription -Force
+  This example shows how to copy all secrets without confirmation when vaults reside in different Azure Subscriptions:
+  .\Copy-AzKeyVaultSecret.ps1 -SourceVaultName <String> -TargetVaultName <String> -SubscriptionId <String> -TargetSubscriptionId <String> -Force
 
   .EXAMPLE
-  This example shows how to copy all secrets without confirmation when vaults resides in different Azure Subscriptions:
-  .\Copy-AzKeyVaultSecret.ps1 -VaultName <String> -TargetVaultName <String> -SubscriptionId <String> -TargetSubscriptionId <String> -Force
-
-  .EXAMPLE
-  This example shows same example as previous + use of SkipSecrets Parameter. SkipSecrets support multiple values:
-  .\Copy-AzKeyVaultSecret.ps1 -VaultName <String> -TargetVaultName <String> -SubscriptionId <String> -TargetSubscriptionId <String> -Force -SkipSecrets <String>, <String>, <String>
+  This example shows the same example as previous + use of SkipSecrets Parameter. SkipSecrets supports multiple values:
+  .\Copy-AzKeyVaultSecret.ps1 -SourceVaultName <String> -TargetVaultName <String> -SubscriptionId <String> -TargetSubscriptionId <String> -Force -SkipSecrets <String>, <String>, <String>
 #>
 
 param (
     [Parameter(Mandatory = $true)]
-    [string]$VaultName,
+    [string]$SourceVaultName,
 
     [Parameter(Mandatory = $true)]
     [string]$TargetVaultName,
@@ -75,7 +71,7 @@ param (
     [string]$TargetSubscriptionId,
 
     [Parameter(Mandatory = $false)]
-    [string[]]$Name,
+    [string[]]$SecretName,
 
     [Parameter(Mandatory = $false)]
     [string[]]$SkipSecrets,
@@ -89,12 +85,15 @@ param (
 
 $InformationPreference = 'Continue'
 
+# Log into Azure using a managed identity, for use in an Azure Automation Runbook.
 function aaLogin {
     Disable-AzContextAutosave -Scope Process
     $AzureContext = (Connect-AzAccount -Identity).context
-    $AzureContext = Set-AzContext -SubscriptionId $subscriptionId -DefaultProfile $AzureContext
+    Set-AzContext -SubscriptionId $SubscriptionId -DefaultProfile $AzureContext
 }
-function Set-AzSubscription {
+
+# Set and verify Azure Subscription Context
+function Set-SubscriptionContext {
 
     param (
         [Parameter(Mandatory = $true)]
@@ -102,9 +101,9 @@ function Set-AzSubscription {
     )
 
     # Set Context to correct Subscription.
-    Set-AzContext -Subscription $SubscriptionId
+    Set-AzContext -SubscriptionId $SubscriptionId
 
-    # Check Subscription Context
+    # Verify Subscription Context
     $subCheck = (Get-AzContext).Subscription.Id
     try {
         if ($subCheck -ne $SubscriptionId) {
@@ -113,99 +112,118 @@ function Set-AzSubscription {
         }
     }
     catch {
-        Write-Error "Error: $($_.Exception)"
+        Write-Error "Error: $($_.Exception.Message)"
     }
 }
-function Disable-KeyVaultFirewall {
 
+# Temporarily disable Key Vault firewall to allow script to read secrets in Source Vault and write secrets in Target Vault.
+function Disable-KeyVaultFirewall {
     param (
         [Parameter(Mandatory = $true)]
         [string]$VaultName
     )
 
-    $vault = Get-AzKeyVault -VaultName $VaultName -ErrorAction SilentlyContinue
-    $firewallDefaultAction = $vault.NetworkAcls.DefaultAction
-    $firewallEnabled = $firewallDefaultAction -eq 'Deny'
-    if ($firewallEnabled) {
-        $null = Update-AzKeyVaultNetworkRuleSet -VaultName $VaultName -DefaultAction 'Allow'
+    $Vault = Get-AzKeyVault -VaultName $VaultName -ErrorAction SilentlyContinue
+    if ($Vault) {
+        $FirewallDefaultAction = $Vault.NetworkAcls.DefaultAction
+        $FirewallEnabled = $FirewallDefaultAction -eq 'Deny'
+
+        if ($FirewallEnabled) {
+            Write-Output "Firewall is currently set to 'Deny' for $VaultName. Changing to 'Allow'."
+            $null = Update-AzKeyVaultNetworkRuleSet -VaultName $VaultName -DefaultAction 'Allow'
+        }
+
+        return $FirewallEnabled
+    }
+    else {
+        Write-Error "Failed to get Key Vault information for $VaultName. Please check the vault name and try again."
+        exit 1
     }
 }
+
 try {
     if ($Runbook) {
         aaLogin
     }
-    # Set AzContext and make sure FireWall is set to "Allowed" to be able to access secrets
-    Set-AzSubscription -SubscriptionId $SubscriptionId
-    Disable-KeyVaultFirewall -VaultName $VaultName
-    Disable-KeyVaultFirewall -VaultName $TargetVaultName
 
-    #Check if Source and Target Vaults exists
-    $srcVault = Get-AzKeyVault -VaultName $VaultName -ErrorAction SilentlyContinue
-    $dstVault = Get-AzKeyVault -VaultName $TargetVaultName -ErrorAction SilentlyContinue
+    # Set Context and make sure FireWall is set to "Allowed" to be able to access secrets
+    Set-SubscriptionContext -SubscriptionId $SubscriptionId
+    $SourceVaultFirewall = Disable-KeyVaultFirewall -VaultName $SourceVaultName
+    $TargetVaultFirewall = Disable-KeyVaultFirewall -VaultName $TargetVaultName
 
-    # Skip Secrets form Copy operation if specified in $SkipSecrets Parameter
-    if ($SkipSecrets) {
+    # Check if Source and Target Vaults exist
+    $SourceVault = Get-AzKeyVault -VaultName $SourceVaultName -ErrorAction SilentlyContinue
+    $TargetVault = Get-AzKeyVault -VaultName $TargetVaultName -ErrorAction SilentlyContinue
+
+    if ($SourceVault -and $TargetVault) {
+        # Skip Secrets from Copy operation if specified in $SkipSecrets Parameter
         $exclusionList = @()
-        $exclusionList += $SkipSecrets
-    }
-    if ($srcVault -and $dstVault) {
-        # Run this block if no input in parameter $Name specified
-        if (!$Name) {
+        if ($SkipSecrets) {
+            $exclusionList += $SkipSecrets
+        }
+
+        # Run this block if no input in parameter $SecretName specified
+        if (!$SecretName) {
             if ($SkipSecrets) {
-                $Name = (Get-AzKeyVaultSecret -VaultName $VaultName).Name | Where-Object { -not $exclusionList.Contains("$($_)") } | Sort-Object
+                $SecretName = (Get-AzKeyVaultSecret -VaultName $SourceVaultName).Name | Where-Object { -not $exclusionList.Contains($_) } | Sort-Object
             }
+
             else {
-                $Name = (Get-AzKeyVaultSecret -VaultName $VaultName).Name | Sort-Object
+                $SecretName = (Get-AzKeyVaultSecret -VaultName $SourceVaultName).Name | Sort-Object
             }
         }
-        foreach ($n in $Name) {
-            # Get key vault secret
-            $srcSecretValue = Get-AzKeyVaultSecret -VaultName $VaultName -Name $n -AsPlainText -ErrorAction SilentlyContinue
-            $srcSecret = Get-AzKeyVaultSecret -VaultName $VaultName -Name $n -ErrorAction SilentlyContinue
 
-            # Set Destination Subscription Context if available
+        foreach ($n in $SecretName) {
+            # Get secret from source Key Vault
+            $SourceSecretValue = Get-AzKeyVaultSecret -VaultName $SourceVaultName -Name $n -AsPlainText -ErrorAction SilentlyContinue
+            $SourceSecret = Get-AzKeyVaultSecret -VaultName $SourceVaultName -Name $n -ErrorAction SilentlyContinue
+
+            # Set Target Subscription Context if available
             if ($TargetSubscriptionId) {
                 $null = Set-AzContext -SubscriptionId $TargetSubscriptionId
             }
-            # Compare Source and Destination Secret Values
-            <# Only copy if value of secret and existing destination do not match.
-            We need to convert secrets to plain text to be able to compare secret values in different keyvaults.
-            This is needed when copying/updating/backing_up secrets with a powershell script.
-            Default action of PowerShell command "Set-AzKeyVaultSecret" is creating new versions even when secrets have same SecretValue.
-            This is why we are comparing secrets, to be able to prevent new sercret versions with exact same secret values.#>
-            $dstSecretValue = Get-AzKeyVaultSecret -VaultName $TargetVaultName -Name $n -AsPlainText -ErrorAction SilentlyContinue
-            if ($srcSecretValue -ne $dstSecretValue) {
-                $SecretValue = $srcSecretValue | ConvertTo-SecureString -AsPlainText -Force
+
+            # Compare Source and Target Secret Values
+            $TargetSecretValue = Get-AzKeyVaultSecret -VaultName $TargetVaultName -Name $n -AsPlainText -ErrorAction SilentlyContinue
+
+            if ($SourceSecretValue -ne $TargetSecretValue) {
+                $SecretValue = $SourceSecretValue | ConvertTo-SecureString -AsPlainText -Force
                 $Copy = Set-AzKeyVaultSecret `
                     -VaultName $TargetVaultName `
                     -SecretValue $SecretValue `
-                    -Name $srcSecret.Name `
-                    -Expires $srcSecret.Expires `
-                    -ContentType $srcSecret.ContentType `
-                    -Tag $srcSecret.Tags `
+                    -Name $SourceSecret.Name `
+                    -Expires $SourceSecret.Expires `
+                    -ContentType $SourceSecret.ContentType `
+                    -Tag $SourceSecret.Tags `
                     -Confirm:(!$Force)
                 Write-Output "Successfully copied secret name '$($Copy.Name)' with id '$($Copy.Id)'"
             }
+
             else {
-                Write-Output "Secret Name '$($srcSecret.Name)' with id '$($srcSecret.id)'already existing in destination vault"
+                Write-Output "Secret Name '$($SourceSecret.Name)' with id '$($SourceSecret.Id)' already exists in destination vault"
             }
         }
     }
 }
+
 catch {
-    Write-Error "Error: $($_.Exception)"
+    Write-Error "Error: $($_.Exception.Message)"
 }
+
 finally {
     # Void secrets
-    $srcSecretValue = ""
-    $dstSecretValue = ""
+    $SourceSecretValue = ""
+    $TargetSecretValue = ""
     $SecretValue = ""
-    # Switch Source Vault Firewall back to Deny if default action was 'Deny'
-    if ($srcFirewallEnabled) {
-        $null = Update-AzKeyVaultNetworkRuleSet -VaultName $VaultName -DefaultAction 'Deny'
+
+    # Revert firewall settings if changed
+    if ($SourceVaultFirewall) {
+        Write-Output "Reverting firewall settings for Source Vault to 'Deny'."
+        $null = Update-AzKeyVaultNetworkRuleSet -VaultName $SourceVaultName -DefaultAction 'Deny'
     }
-    # Switch Destination Vault Firewall back to Deny if default action was 'Deny'
-    if ($dstFirewallEnabled) {
+
+    if ($TargetVaultFirewall) {
+        Write-Output "Reverting firewall settings for Target Vault to 'Deny'."
         $null = Update-AzKeyVaultNetworkRuleSet -VaultName $TargetVaultName -DefaultAction 'Deny'
     }
 }


### PR DESCRIPTION
Original issue was that when running the script we got the following warning:

```terminal
WARNING: Set-AzSubscription is not found. The most similar Azure PowerShell commands are:
        Get-AzSubscription
        Select-AzSubscription
```

This refers to the custom fuction `Set-AzSubscription` on line 97. I believe the issue was that the custom function name was too similar to an actual built-in Azure PowerShell cmdlet, which does not exist. To fix this I just changed the custom function name from `Set-AzSubscription` to `Set-SubscriptionContext`, and updated the references. 

Simultaneously I did some formatting, added some comments and updated the parameter names.

## Testing 
- Copying secrets from one key vault to another in the same subscription works as it should.
- Have not yet tested copying secrets across different subscriptions, but will test this asap.
- Have not tested the script with use of runbook.
- Disabling/enabling firewall works as expected. Output below:
    ```terminal
    WARNING: The network rule set has been turned off for this vault.
    WARNING: The network rule set has been turned off for this vault.
    Secret Name 'secret-1' with id 'https://kv-test-hekal.vault.azure.net:443/secrets/secret-1/84a4a19f9d4c47ebaa641ec104ed9560' already exists in destination vault
    Secret Name 'secret-2' with id 'https://kv-test-hekal.vault.azure.net:443/secrets/secret-2/612fa637e8d44b59adce25d798924442' already exists in destination vault
    Secret Name 'secret-3' with id 'https://kv-test-hekal.vault.azure.net:443/secrets/secret-3/7c229dcbd8ff4567b90eb5052d29ffd5' already exists in destination vault
    Reverting firewall settings for Source Vault to 'Deny'.
    Reverting firewall settings for Target Vault to 'Deny'.
    ```